### PR TITLE
del: implement DEL command

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,6 +18,7 @@ const (
 	opHKeys   = "HKEYS"
 	opHExists = "HEXISTS"
 	opExec    = "EXEC"
+	opDel     = "DEL"
 
 	EnvRedisServerURL = "REDIS_SERVER_URL"
 )
@@ -97,8 +98,8 @@ func multiKeysOp(c *Client, opName, hashTableName string, keys ...interface{}) (
 	return c.doHashOp(opName, hashTableName, keys...)
 }
 
-func byKeyOp(c *Client, opName, hashTableName string, key interface{}) (interface{}, error) {
-	replies, err := multiKeysOp(c, opName, hashTableName, key)
+func byKeyOp(c *Client, opName, hashTableName string, keys ...interface{}) (interface{}, error) {
+	replies, err := multiKeysOp(c, opName, hashTableName, keys)
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +161,13 @@ func (c *Client) HLen(hashTableName string) (int64, error) {
 
 	vStr := fmt.Sprintf("%v", first)
 	return strconv.ParseInt(vStr, 10, 64)
+}
+
+// Del deletes one or more collections by the
+// collection name, where any of the types are:
+// hash, set, sorted set, list.
+func (c *Client) Del(firstTable string, otherTables ...interface{}) (interface{}, error) {
+	return byKeyOp(c, opDel, firstTable, otherTables...)
 }
 
 func (c *Client) HExists(hashTableName string, key interface{}) (bool, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -163,6 +163,34 @@ func clearTable(client *Client, tableName string) (pass, fail uint64) {
 	return pass, fail
 }
 
+func TestDel(t *testing.T) {
+	client, err := newTestClient()
+	if err != nil {
+		t.Fatalf("creating client err=%v", err)
+	}
+
+	table := uuid.NewRandom().String()
+	var otherTables []interface{}
+	for i := 0; i < 3; i++ {
+		otherTables = append(otherTables, uuid.NewRandom().String())
+	}
+
+	cleanup := func() error {
+		_, err := client.Del(table, otherTables...)
+		return err
+	}
+
+	for i := 0; i < 10; i++ {
+		strKey := fmt.Sprintf("%d", i)
+		if _, err := client.HSet(table, strKey, strKey); err != nil {
+			_ = cleanup()
+			t.Fatalf("#%d: failed to HSet: %v", i, err)
+		}
+	}
+
+	defer cleanup()
+}
+
 func TestHMove(t *testing.T) {
 	client, err := newTestClient()
 	if err != nil {


### PR DESCRIPTION
Fixes #6.

Implement the collection deleting command
that takes at least one key of a collection
to entirely delete.
Works on list, sorted set, hash, set.