### PR TITLE
multiKeyOp: fix unintended conversion from []interface{} to interface{}

### DIFF
--- a/client.go
+++ b/client.go
@@ -82,7 +82,6 @@ func (c *Client) doHashOp(opName, hashTableName string, args ...interface{}) ([]
 	if sendErr := c.conn.Send(opName, allArgs...); sendErr != nil {
 		return nil, sendErr
 	}
-
 	return redis.Values(c.conn.Do(opExec))
 }
 
@@ -99,7 +98,7 @@ func multiKeysOp(c *Client, opName, hashTableName string, keys ...interface{}) (
 }
 
 func byKeyOp(c *Client, opName, hashTableName string, keys ...interface{}) (interface{}, error) {
-	replies, err := multiKeysOp(c, opName, hashTableName, keys)
+	replies, err := multiKeysOp(c, opName, hashTableName, keys...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A bug has existed for long in which doing multiOP operations
would cause a key passed in as say:

HGET 839c17fc-df0a-4b37-8864-83745a717675 foo
Then being converted into
HGET 839c17fc-df0a-4b37-8864-83745a717675 [foo]

Because of the multi-step composition from
* Client.HGet (hashTableName string, key interface{})
* byKeyOp(*Client, op, hashTableName string, keys ...interface{})
* multiKeysOp(*Client, op, hashTableName string, keys ...interface{})

Diagnosis and problem explanation:
Now the problem existed in byKeyOp where multiKeysOp was being invoked
as:
multiKeysOp(*Client, op, hashTableName, keys)

which would make keys []interface{} or (...interface{}) into just a
single interface{} value since []interface{} -> interface{}
which then caused the problem causing a bunch of cache misses.

What a bug!!