### PR TITLE
connection pool instead of a single connection

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -238,7 +238,7 @@ func TestHMove(t *testing.T) {
 		for key, liveValue := range kvpMap {
 			retrValue, err := client.HMove(primary, secondary, key)
 			if err != nil {
-				t.Errorf("#%d: err=%v for HMove wantErr=nil; primary=%v secondary=%v", i, primary, secondary)
+				t.Errorf("#%d: err=%v for HMove wantErr=nil; primary=%v secondary=%v", i, err, primary, secondary)
 			}
 
 			// We can only compare by string repr comparsions
@@ -369,14 +369,18 @@ func TestSAddMembersPush(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				wantBlob, _ := json.Marshal([]interface{}{`"a"`, `2`, `3`})
-
-				var collected []interface{}
-				listing := retr.([]interface{})
-				for _, t := range listing {
-					collected = append(collected, fmt.Sprintf("%s", t))
+				wantMap := map[interface{}]bool{
+					"a": true,
+					2:   true,
+					3:   true,
 				}
-				gotBlob, _ := json.Marshal(collected)
+				listing := retr.([]interface{})
+				gotMap := make(map[interface{}]bool)
+				for _, t := range listing {
+					gotMap[fmt.Sprintf("%s", t)] = true
+				}
+				wantBlob, _ := json.Marshal(wantMap)
+				gotBlob, _ := json.Marshal(gotMap)
 				if !bytes.Equal(wantBlob, gotBlob) {
 					return fmt.Errorf("got=%q want=%q", gotBlob, wantBlob)
 				}

--- a/example_test.go
+++ b/example_test.go
@@ -32,7 +32,7 @@ func ExampleMulticonsumer() {
 	for i, kvp := range kvps {
 		_, err := client.HSet(tableName, kvp.key, kvp.value)
 		if err != nil {
-			log.Printf("#%d key:%v value %v failed err %v; comment %s", i, kvp.key, kvp.value, kvp.comment)
+			log.Printf("#%d key:%v value %v failed err %v; comment %s", i, kvp.key, kvp.value, err, kvp.comment)
 		}
 	}
 }


### PR DESCRIPTION
Use a redis.Pool underneath event though singlely
dispense out a connection. The purpose is to aid
in automatic retries since historically connecting
directly makes the connection fail and never retry.
With the pool, the connection can be closed and
a new one retrieved from the pool.